### PR TITLE
Fix error where the colon wasn't escaped

### DIFF
--- a/tests/titlecase-tests.el
+++ b/tests/titlecase-tests.el
@@ -78,6 +78,14 @@
  non_ascii_multiple_1
  "απω απω"
  "Απω Απω")
+(ert-deftest-decl-pair ;; See issue #11.
+ punctuation-colon-1
+ "test: of mice and men"
+ "Test: Of Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-semicolon-1
+ "test; of mice and men"
+ "Test; Of Mice and Men")
 
 (provide 'titlecase-tests)
 ;;; titlecase-tests.el ends here

--- a/titlecase.el
+++ b/titlecase.el
@@ -155,7 +155,7 @@
   "What to do to a word when a style doesn't specify what to do."
   :type 'function)
 
-(defcustom titlecase-force-cap-after-punc "[:.?;\n\r]"
+(defcustom titlecase-force-cap-after-punc "[.?;\\:\n\r]"
   "Regexp to force the next word capitalized."
   :type 'regexp)
 


### PR DESCRIPTION
':' didn't cause capitalization to reset.