### PR TITLE
Don't set match data unnecessarily

### DIFF
--- a/titlecase.el
+++ b/titlecase.el
@@ -185,7 +185,7 @@
           (setq this-word (current-word))
           (cond
            ;; Skip ALL-CAPS words
-           ((string-match "^[[:upper:]]+$" this-word)
+           ((string-match-p "^[[:upper:]]+$" this-word)
             (forward-word 1))
            ;; Phrasal verbs!
            ((and (memq style titlecase-styles-capitalize-phrasal-verbs)
@@ -238,7 +238,7 @@
            (t (funcall titlecase-default-case-function 1)))
           ;; If the word ends with a :, ., ?, newline, or carriage-return,
           ;; force the next word to be capitalized.
-          (setq force-capitalize (looking-at titlecase-force-cap-after-punc))
+          (setq force-capitalize (looking-at titlecase-force-cap-after-punc t))
           (skip-syntax-forward "^w" end))
         ;; Capitalize the last word, only in some styles
         (when (memq style titlecase-styles-capitalize-last-word)


### PR DESCRIPTION
Even though this is inside a 'save-match-data' block,
the intention is better communicated when match data isn't being set.