### PR TITLE
Fix white space or other non-word characters ignoring delimiters

### DIFF
--- a/tests/titlecase-tests.el
+++ b/tests/titlecase-tests.el
@@ -38,7 +38,7 @@
   `(ert-deftest ,test-id ()
      (with-temp-buffer
        (insert ,text-initial)
-       (titlecase-dwim)
+       (titlecase-region (point-min) (point-max))
        (should (equal ,text-expected (buffer-string))))))
 
 ;; Tests.
@@ -90,6 +90,23 @@
  punctuation-semicolon-1
  "test; of mice and men"
  "Test; Of Mice and Men")
+
+(ert-deftest-decl-pair
+ punctuation-newline_1
+ "test\nof mice and men"
+ "Test\nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_2
+ "test \nof mice and men"
+ "Test \nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_3
+ "test@\nof mice and men"
+ "Test@\nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_4
+ "test\n@of mice and men"
+ "Test\n@Of Mice and Men")
 
 (provide 'titlecase-tests)
 ;;; titlecase-tests.el ends here

--- a/titlecase.el
+++ b/titlecase.el
@@ -240,8 +240,22 @@
            (t (funcall titlecase-default-case-function 1)))
           ;; If the word ends with a :, ., ?, newline, or carriage-return,
           ;; force the next word to be capitalized.
-          (setq force-capitalize (looking-at titlecase-force-cap-after-punc t))
-          (skip-syntax-forward "^w" end))
+          ;;
+          ;; Even though the majority of cases will end with the delimiter,
+          ;; there may be trailing space or other kinds of delimiters
+          ;; proceeding the known characters - which should not prevent
+          ;; the known delimiters from being detected.
+          ;; For this reason - check all text for delimiters between words.
+          (let ((pos-prev (point))
+                (pos-next
+                 (progn
+                   (skip-syntax-forward "^w" end)
+                   (point))))
+            (setq force-capitalize
+                  (save-excursion
+                    (goto-char pos-prev)
+                    (re-search-forward titlecase-force-cap-after-punc
+                                       pos-next :noerror)))))
         ;; Capitalize the last word, only in some styles
         (when (memq style titlecase-styles-capitalize-last-word)
           (backward-word 1)


### PR DESCRIPTION
Delimiters (including new-lines) that existed between words
were ignored if there was white space or other non-word characters
before them.

This meant (for example) that trailing space at the end of a line
would cause the new-line to be ignored as a delimiter.

Add tests - all of them failed before this fix.