### PR TITLE
Fix white space or other non-word characters ignoring delimiters

### DIFF
--- a/tests/titlecase-tests.el
+++ b/tests/titlecase-tests.el
@@ -38,7 +38,7 @@
   `(ert-deftest ,test-id ()
      (with-temp-buffer
        (insert ,text-initial)
-       (titlecase-dwim)
+       (titlecase-region (point-min) (point-max))
        (should (equal ,text-expected (buffer-string))))))
 
 ;; Tests.
@@ -90,6 +90,23 @@
  punctuation-semicolon-1
  "test; of mice and men"
  "Test; Of Mice and Men")
+
+(ert-deftest-decl-pair
+ punctuation-newline_1
+ "test\nof mice and men"
+ "Test\nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_2
+ "test \nof mice and men"
+ "Test \nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_3
+ "test@\nof mice and men"
+ "Test@\nOf Mice and Men")
+(ert-deftest-decl-pair
+ punctuation-newline_4
+ "test\n@of mice and men"
+ "Test\n@Of Mice and Men")
 
 (provide 'titlecase-tests)
 ;;; titlecase-tests.el ends here


### PR DESCRIPTION
Delimiters (including new-lines) that existed between words
were ignored if there was white space or other non-word characters
before them.

This meant (for example) that trailing space at the end of a line
would cause the new-line to be ignored as a delimiter.

Add tests - all of them failed before this fix.

---

This also refactors the main loop into two functions,
so capitalizing between delimiters is handled in an outer loop.

This simplifies logic elsewhere.

---

NOTE: this is more of a refactor, which resolves the same issues as #17, with less complexity as using the bounding delimiters have been moved into an outer loop. This is somewhat personal preference, but I find it makes the logic easier to follow.