### PR TITLE
Add closing single quote as apostrophe

### DIFF
--- a/tests/titlecase-tests.el
+++ b/tests/titlecase-tests.el
@@ -105,6 +105,10 @@
  "don't work"
  "Don't Work")
 (ert-deftest-decl-pair
+ apostrophe_2
+ "don’t work"
+ "Don’t Work")
+(ert-deftest-decl-pair
  non_ascii_single_1 ;; See issue #1.
  "π"
  "Π")

--- a/titlecase.el
+++ b/titlecase.el
@@ -210,8 +210,7 @@ for docs on BEGIN, END and STYLE."
              (eq style 'sentence)
              ;; None of the styles require a capital letter after an
              ;; apostrophe.
-             (eq (char-before (point)) ?')
-             (eq (char-before (point)) ?’)
+             (memq (char-before (point)) '(?' ?’))
              ;; FIXME: Hyphens are a completely different story with
              ;; capitalization.
              (eq (char-before (point)) ?-))

--- a/titlecase.el
+++ b/titlecase.el
@@ -211,6 +211,7 @@ for docs on BEGIN, END and STYLE."
              ;; None of the styles require a capital letter after an
              ;; apostrophe.
              (eq (char-before (point)) ?')
+             (eq (char-before (point)) ?’)
              ;; FIXME: Hyphens are a completely different story with
              ;; capitalization.
              (eq (char-before (point)) ?-))


### PR DESCRIPTION
This PR adds the closing single quote (``’``) as a use case for an apostrophe. 

A minor mode like `typo-mode` automatically converts the ASCII single quote (``'``) to the aforementioned character, e.g., [Emacs Wiki: TypographicalPunctuationMarks](https://www.emacswiki.org/emacs/TypographicalPunctuationMarks). This is useful for editing in such a mode.